### PR TITLE
Issue 9 Refactored the workflow of DPX Post RawCooked Scripts

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ; FILM_OPS=/run/user/1001/gvfs/smb-share:server=vhi.dr-nas.usc.edu,share=dr-store/HIRSCH/badScans/RawCookedDirectory/
-; FILM_OPS=/home/tnandi/Desktop/rawcooked_usc-dr/
-FILM_OPS=/home/postsuper/Desktop/rawcooked_usc-dr/
+FILM_OPS=/home/tnandi/Desktop/rawcooked_usc-dr/
+; FILM_OPS=/home/postsuper/Desktop/rawcooked_usc-dr/
 DPX_SCRIPT_LOG=logs/
 DPX_ASSESS=media/encoding/dpx_to_assess/
 POLICY_DPX=policy/rawcooked_dpx_policy.xml

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ; FILM_OPS=/run/user/1001/gvfs/smb-share:server=vhi.dr-nas.usc.edu,share=dr-store/HIRSCH/badScans/RawCookedDirectory/
 ; FILM_OPS=/home/tnandi/Desktop/rawcooked_usc-dr/
-FILM_OPS=/home/postsuper/Desktop/rawcooked_usc-dr
+FILM_OPS=/home/postsuper/Desktop/rawcooked_usc-dr/
 DPX_SCRIPT_LOG=logs/
 DPX_ASSESS=media/encoding/dpx_to_assess/
 POLICY_DPX=policy/rawcooked_dpx_policy.xml
@@ -18,5 +18,5 @@ PART_RAWCOOK=media/encoding/part_whole_split/rawcook/
 PART_TAR=media/encoding/part_whole_split/tar/
 DPX_COMPLETE=media/encoding/dpx_completed/
 MKV_CHECK=media/encoding/rawcooked/encoded/check/
-POLICY_RAWCOOK=rawcooked_mkv_policy.xml
+POLICY_RAWCOOK=policy/rawcooked_mkv_policy.xml
 

--- a/scripts/dpx_assessment.py
+++ b/scripts/dpx_assessment.py
@@ -60,6 +60,10 @@ class DpxAssessment:
             print("No files available for encoding, script exiting")
             sys.exit(1)
 
+        if not os.path.exists(self.logfile):
+            with open(self.logfile, 'w+'):
+                pass
+
         if not os.path.exists(self.success_file):
             with open(self.success_file, 'w+'):
                 pass

--- a/scripts/dpx_post_rawcook.py
+++ b/scripts/dpx_post_rawcook.py
@@ -15,307 +15,343 @@ load_dotenv()
 # ====================================================================
 # === Clean up and inspect logs for problem DPX sequence encodings ===
 # ====================================================================
-ERRORS = os.environ.get('FILM_OPS') + os.environ.get('CURRENT_ERRORS')
-DPX_PATH = os.environ.get('FILM_OPS') + os.environ.get('RAWCOOKED_PATH')
-DPX_DEST = os.environ.get('FILM_OPS') + os.environ.get('DPX_COMPLETE')
-MKV_DESTINATION = os.environ.get('FILM_OPS') + os.environ.get('MKV_ENCODED')
-CHECK_FOLDER = os.environ.get('FILM_OPS') + os.environ.get('MKV_CHECK')
-MKV_POLICY = os.environ.get('POLICY_RAWCOOK')
-SCRIPT_LOG = os.environ.get('FILM_OPS') + os.environ.get('DPX_SCRIPT_LOG')
+ERRORS = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('CURRENT_ERRORS'))
+DPX_PATH = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('RAWCOOKED_PATH'))
+DPX_DEST = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('DPX_COMPLETE'))
+MKV_DESTINATION = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('MKV_ENCODED'))
+CHECK_FOLDER = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('MKV_CHECK'))
+MKV_POLICY = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('POLICY_RAWCOOK'))
+SCRIPT_LOG = os.path.join(os.environ.get('FILM_OPS') + os.environ.get('DPX_SCRIPT_LOG'))
 
-logfile = SCRIPT_LOG + "dpx_post_rawcook.log"
+logfile = os.path.join(SCRIPT_LOG, "dpx_post_rawcook.log")
 date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
-# Check mkv_cooked/ folder populated before starting log writes
-if any(os.scandir(MKV_DESTINATION + 'mkv_cooked/')):
-    log(logfile, "===================== Post-RAWcook workflows STARTED =====================")
-    log(logfile, "Files present in mkv_cooked folder, checking if ready for processing...")
-else:
-    print("MKV folder empty, script exiting")
 
-# Script temporary file recreate (delete at end of script)
-temp_medicaconch_policy_fails_file = MKV_DESTINATION + "temp_medicaconch_policy_fails.txt"
-successfull_mkv_list_file = MKV_DESTINATION + "successfull_mkv_list.txt"
-matroska_deletion_file = MKV_DESTINATION + "matroska_deletion.txt"
-matroske_deletion_list_file = MKV_DESTINATION + "matroske_deletion_list.txt"
-stale_encodings_file = MKV_DESTINATION + "stale_encodings.txt"
-error_list_file = MKV_DESTINATION + "error_list.txt"
-reversibility_list_file = MKV_DESTINATION + "reversibility_list.txt"
+class DpxPostRawcook:
+    def __init__(self):
+        self.temp_medicaconch_policy_fails_file = os.path.join(MKV_DESTINATION, "temp_medicaconch_policy_fails.txt")
+        self.successfull_mkv_list_file = os.path.join(MKV_DESTINATION, "successfull_mkv_list.txt")
+        self.matroska_deletion_file = os.path.join(MKV_DESTINATION, "matroska_deletion.txt")
+        self.matroske_deletion_list_file = os.path.join(MKV_DESTINATION, "matroske_deletion_list.txt")
+        self.stale_encodings_file = os.path.join(MKV_DESTINATION, "stale_encodings.txt")
+        self.error_list_file = os.path.join(MKV_DESTINATION, "error_list.txt")
+        self.reversibility_list_file = os.path.join(MKV_DESTINATION, "reversibility_list.txt")
 
-file_names = [temp_medicaconch_policy_fails_file, successfull_mkv_list_file, matroska_deletion_file,
-              matroske_deletion_list_file, stale_encodings_file, error_list_file, reversibility_list_file]
+        self.file_names = [
+            self.temp_medicaconch_policy_fails_file, self.successfull_mkv_list_file, self.matroska_deletion_file,
+            self.matroske_deletion_list_file, self.stale_encodings_file, self.error_list_file,
+            self.reversibility_list_file
+        ]
 
-for file_name in file_names:
-    with open(file_name, 'w') as f:
-        pass
-
-# =======================================================================================
-# Matroska size check remove files to Killed folder, and folders moved to check_size/ ===
-# DO NOT NEED THIS LOGIC --- ******************SKIPPING**************************** -----
-# =======================================================================================
-
-# ==========================================================================
-# Matroska checks using MediaConch policy, remove fails to Killed folder ===
-# ==========================================================================
-with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
-    for entry in entries:
-        filename = entry.name
-        fname_log = filename.split('.')[0]
-        if filename.endswith(".mkv") or filename.endswith(
-                ".rawcooked_reversibility_data"):  # TODO check this file name ending. Should be .mkv only
-            check = check_mediaconch_policy(MKV_POLICY, filename)
-            check_str = check.stdout.decode()
-            if ".mkv.r" in check_str:  # check_str.startswith('pass!'):
-                log(logfile, "PASS: RAWcooked MKV file " + filename + " has passed the Mediaconch policy. Whoopee")
-            else:
-                log(logfile, "FAIL: RAWcooked MKV " + filename + " has failed the mediaconch policy")
-                log(logfile, "Moving " + filename + " to killed directory, and amending log fail_" + filename + ".txt")
-                log(logfile, check)
-                with open(ERRORS + fname_log + "_errors.log", 'a+') as file:
-                    file.write(
-                        "post_rawcooked" + date + "): Matroska " + filename + " failed the FFV1 MKV Mediaconch policy.")
-                    file.write("    Matroska moved to Killed folder, DPX sequence will retry RAWcooked encoding.")
-                    file.write(
-                        "    Please contact the Knowledge and Collections Developer about this Mediaconch policy failure.")
-                with open(temp_medicaconch_policy_fails_file, "a+") as file:
-                    file.write(filename)
-
-# Move failed MKV files to killed folder
-failed_mkv_file_list = []
-failed_txt_file_list = []
-with open(temp_medicaconch_policy_fails_file, 'r') as file:
-    for line in file:
-        if line.endswith(".mkv"):
-            failed_mkv_file_list.append(line)
-        elif line.endswith(".txt"):
-            failed_txt_file_list.append(line)
-move_files_parallel(MKV_DESTINATION + 'mkv_cooked/', MKV_DESTINATION + 'killed/', failed_mkv_file_list,
-                    10)  # TODO rename mkv_cooked to a vairable
-# Move the txt files to logs folder and prepend -fail- to filename
-
-move_files_parallel(MKV_DESTINATION + 'mkv_cooked/', MKV_DESTINATION + 'logs/', failed_txt_file_list,
-                    10)  # TODO prepend fail_
-# ===================================================================================
-# Log check passes move to MKV Check folder and logs folders, and DPX folder move ===
-# ===================================================================================
-with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
-    for entry in entries:
-        filename = entry.name
-        if filename.endswith("mkv.txt"):
-            with open(MKV_DESTINATION + "mkv_cooked/" + filename, 'r') as file:
-                for line in file:
-                    if (line.find('Reversibility was checked, no issue detected.') != -1):
-                        mkv_filename = filename.split('.')[0] + '.mkv'
-                        dpx_success_path = entry.path
-                        log(logfile,
-                            "COMPLETED: RAWcooked MKV " + mkv_filename + "has completed successfully and will be moved to check folder")
-                        with open(MKV_DESTINATION + "rawcooked_success.log", "a") as file:
-                            file.write(dpx_success_path)
-                        with open(successfull_mkv_list_file, "a") as file:
-                            file.write(mkv_filename)
-                    else:
-                        log(logfile, "SKIP: Matroska " + mkv_filename + " has not completed, or has errors detected")
-
-# Move successfully encoded MKV files to check folder
-successful_mkv_list = []
-successful_mkv_txt_list = []
-with open(successfull_mkv_list_file, 'r') as file:
-    for line in file:
-        if line.endswith(".mkv"):
-            successful_mkv_list.append(line)
-        elif line.endswith(".txt"):
-            successful_mkv_txt_list.append(line)
-
-# Move successfully encoded MKV files to check folder
-move_files_parallel(MKV_DESTINATION + "mkv_cooked/", CHECK_FOLDER, successful_mkv_list, 10)
-
-# Move the successful txt files to logs folder
-move_files_parallel(MKV_DESTINATION + "mkv_cooked/", MKV_DESTINATION + 'logs/', successful_mkv_txt_list, 10)
-
-# Move successful DPX sequence folders to dpx_completed/
-successful_mkv_folder_list = [item.split('.')[0] for item in successful_mkv_list]
-
-# Add list of moved items to post_rawcooked.log
-if os.path.getsize(successfull_mkv_list_file) > 0:
-    # Log the message
-    log(logfile, "Successful Matroska files moved to check folder, DPX sequences for each moved to dpx_completed:\n")
-    with open(logfile, 'w') as file:
-        file.write("\n".join(os.listdir(successfull_mkv_list_file)))
-else:
-    print("File is empty, skipping")
-
-# ==========================================================================
-# Error: the reversibility file is becoming big. --output-version 2 pass ===
-# =========================================================================
-with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
-    for entry in entries:
-        if entry.name.endswith(".mkv.txt"):
-            error_check = False
-            retry_check = False
-            mkv_fname1 = entry.name
-            dpx_folder1 = mkv_fname1.split(".")[0]
-            with open(MKV_DESTINATION + "mkv_cooked/" + entry.name) as file:
-                for line in file:
-                    if line.find(
-                            "'Error: undecodable file is becoming too big.\|Error: the reversibility file is becoming big.'") != -1:
-                        error_check = True
-            file.close()  # TODO close all opened files
-            if error_check:
-                log(logfile, "MKV " + mkv_fname1 + " log has no large reversibility file warning. Skipping")
-            else:
-                with open(reversibility_list_file) as file:
-                    for line in file:
-                        if line.find(mkv_fname1):
-                            retry_check = True
-                file.close()
-                if retry_check:
-                    log(logfile, f"NEW ENCODING ERROR: ${mkv_fname1} adding to reversibility_list")
-                    with open(reversibility_list_file, "w") as file:
-                        file.write(f"{DPX_PATH}dpx_to_cook/{dpx_folder1}")
-                    file.close()
-                    shutil.move(entry.name, MKV_DESTINATION + "logs/retry_" + mkv_fname1 + ".txt")
-
-                else:
-                    log(logfile, f"REPEAT ENCODING ERROR: {mkv_fname1} encountered repeated reversilibity data error")
-                    with open(ERRORS + dpx_folder1 + "_errors.log", "w+") as file:
-                        file.write(
-                            f"post_rawcooked {date}: ${mkv_fname1} Repeated reversibility data error for sequence:")
-                        file.write(f"    {DPX_PATH}dpx_to_cook/${dpx_folder1}")
-                        file.write("    The FFV1 Matroska will be deleted.")
-                        file.write(
-                            "    Please contact the Knowledge and Collections Developer about this repeated reversibility failure.")
-                    file.close()
-                    with open(matroska_deletion_file, "w") as file:
-                        file.write(mkv_fname1)
-                    file.close()
-                    shutil.move(MKV_DESTINATION + "mkv_cooked/" + entry.name,
-                                MKV_DESTINATION + "logs/fail_" + mkv_fname1 + ".txt")
-
-# Add list of reversibility data error to dpx_post_rawcooked.log
-if os.path.getsize(matroska_deletion_file) > 0:
-    log(logfile, "MKV files that will be deleted due to reversibility data error in logs (if present):")
-    with open(matroska_deletion_file, 'r') as input_file, open(logfile, 'a') as output_file:
-        deletion_file_name = input_file.read()
-        output_file.write(deletion_file_name)
-        # Delete broken Matroska files if they exist (unlikely as error exits before encoding)
-        if os.path.exists(MKV_DESTINATION + "mkv_cooked/" + deletion_file_name):
-            os.remove(MKV_DESTINATION + "mkv_cooked/" + deletion_file_name)
-    input_file.close()
-    output_file.close()
-else:
-    print("No MKV files for deletion. Skipping.")
-
-# Add reversibility list to logs for reference
-if os.path.getsize(reversibility_list_file):
-    log(logfile, "DPX sequences that will be re-encoded using --output-version 2:")
-    with open(reversibility_list_file, 'r') as input_file, open(logfile, 'a') as output_file:
-        output_file.write(input_file.read())
-    input_file.close()
-    output_file.close()
-else:
-    print("No DPX sequences for re-encoding using --output-version 2. Skipping.")
-
-# TODO make these checks functions rather than checking everything separately
-
-# ===================================================================================
-# General Error/Warning message failure checks - retry or raise in current errors ===
-# ===================================================================================
-error_messages = ["Reversibility was checked, issues detected, see below.", "Error:", "Conversion failed!",
-                  "Please contact info@mediaarea.net if you want support of such content."]
-with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
-    for entry in entries:
-        error_check = False
-        mkv_fname = entry.name
-        dpx_folder = entry.path
-        if entry.name.endswith("mkv.txt"):
-            with open(entry.name, "r") as file:
-                for line in file:
-                    for message in error_messages:
-                        if message in line:
-                            error_check = True
-            file.close()
-        if error_check:
-            log(logfile, f"UNKNOWN ENCODING ERROR: {mkv_fname} encountered error")
-            with open(dpx_folder + "_errors.log", "w") as file:
-                file.write(DPX_PATH + "dpx_to_cook/" + dpx_folder)
-                file.write(f"post_rawcooked {date}: {mkv_fname} Repeat encoding error raised for sequence:")
-                file.write(f"    {DPX_PATH}dpx_to_cook/{dpx_folder}")
-                file.write(f"    Matroska file will be deleted.")
-                file.write(
-                    f"    Please contact the Knowledge and Collections Developer about this repeated encoding failure")
-            file.close()
-            with open(matroska_deletion_file, "a") as file:
-                file.write(f"{mkv_fname}")
-            file.close()
-            shutil.move(entry.name, MKV_DESTINATION + "logs/fail_" + mkv_fname + ".txt")
+    def process(self):
+        # Check mkv_cooked/ folder populated before starting log writes
+        if any(os.scandir(MKV_DESTINATION + 'mkv_cooked/')):
+            log(logfile, "===================== Post-RAWcook workflows STARTED =====================")
+            log(logfile, "Files present in mkv_cooked folder, checking if ready for processing...")
         else:
-            log(logfile, f"MKV {mkv_fname} log has no error messages. Likely an interrupted or incomplete encoding")
+            print("MKV folder empty, script exiting")
 
-# ===============================================================
-# FOR ==== INCOMPLETE ==== - i.e. killed processes ==============
-# ===============================================================
+        for file_name in self.file_names:
+            with open(file_name, 'w'):
+                pass
 
-# This block manages the remaining INCOMPLETE cooks that have been killed or stalled mid-encoding
-with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
-    for entry in entries:
-        if entry.name.endswith(".mkv.txt"):
-            stale_fname = entry.name
-            stale_basename = entry.path
-            fname_log = entry.path.split('/')[0]
+    def check_mediaconch_policies(self):
+        # ==========================================================================
+        # Matroska checks using MediaConch policy, remove fails to Killed folder ===
+        # ==========================================================================
+        with os.scandir(os.path.join(MKV_DESTINATION, "mkv_cooked/")) as entries:
+            for entry in entries:
+                filename = entry.name
+                fname_log = filename.split('.')[0]
+                if filename.endswith(".mkv") or filename.endswith(
+                        ".rawcooked_reversibility_data"):  # TODO check this file name ending. Should be .mkv only
+                    check = check_mediaconch_policy(MKV_POLICY, filename)
+                    check_str = check.stdout.decode()
+                    if ".mkv.r" in check_str:  # check_str.startswith('pass!'):
+                        log(logfile,
+                            "PASS: RAWcooked MKV file " + filename + " has passed the Mediaconch policy. Whoopee")
+                    else:
+                        log(logfile, "FAIL: RAWcooked MKV " + filename + " has failed the mediaconch policy")
+                        log(logfile,
+                            "Moving " + filename + " to killed directory, and amending log fail_" + filename + ".txt")
+                        log(logfile, check)
+                        with open(ERRORS + fname_log + "_errors.log", 'a+') as file:
+                            file.write(
+                                "post_rawcooked" + date + "): Matroska " + filename + "failed the FFV1 MKV Mediaconch "
+                                                                                      "policy.")
+                            file.write(
+                                "    Matroska moved to Killed folder, DPX sequence will retry RAWcooked encoding.")
+                            file.write(
+                                "Please contact the Knowledge and Collections Developer about this Mediaconch policy "
+                                "failure.")
+                        with open(self.temp_medicaconch_policy_fails_file, "a+") as file:
+                            file.write(filename)
+
+        # Move failed MKV files to killed folder
+        failed_mkv_file_list = []
+        failed_txt_file_list = []
+        with open(self.temp_medicaconch_policy_fails_file, 'r') as file:
+            for line in file:
+                if line.endswith(".mkv"):
+                    failed_mkv_file_list.append(line)
+                elif line.endswith(".txt"):
+                    failed_txt_file_list.append(line)
+        move_files_parallel(os.path.join(MKV_DESTINATION, 'mkv_cooked/'), os.path.join(MKV_DESTINATION, 'killed/'),
+                            failed_mkv_file_list, 10)  # TODO rename mkv_cooked to a vairable
+        # Move the txt files to logs folder and prepend -fail- to filename
+
+        move_files_parallel(os.path.join(MKV_DESTINATION, 'mkv_cooked/'), os.path.join(MKV_DESTINATION, 'logs/'),
+                            failed_txt_file_list, 10)  # TODO prepend fail_
+
+    def move_success_files(self):
+        # ===================================================================================
+        # Log check passes move to MKV Check folder and logs folders, and DPX folder move ===
+        # ===================================================================================
+        with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
+            for entry in entries:
+                filename = entry.name
+                if filename.endswith("mkv.txt"):
+                    with open(MKV_DESTINATION + "mkv_cooked/" + filename, 'r') as file:
+                        for line in file:
+                            if line.find('Reversibility was checked, no issue detected.') != -1:
+                                mkv_filename = filename.split('.')[0] + '.mkv'
+                                dpx_success_path = entry.path
+                                log(logfile,
+                                    "COMPLETED: RAWcooked MKV " + mkv_filename + "has completed successfully and will "
+                                                                                 "be moved to check folder")
+                                with open(MKV_DESTINATION + "rawcooked_success.log", "a") as f:
+                                    f.write(dpx_success_path)
+                                with open(self.successfull_mkv_list_file, "a") as f:
+                                    f.write(mkv_filename)
+                            else:
+                                log(logfile,
+                                    "SKIP: Matroska " + mkv_filename + " has not completed, or has errors detected")
+
+        # Move successfully encoded MKV files to check folder
+        successful_mkv_list = []
+        successful_mkv_txt_list = []
+        with open(self.successfull_mkv_list_file, 'r') as file:
+            for line in file:
+                if line.endswith(".mkv"):
+                    successful_mkv_list.append(line)
+                elif line.endswith(".txt"):
+                    successful_mkv_txt_list.append(line)
+
+        # Move successfully encoded MKV files to check folder
+        move_files_parallel(os.path.join(MKV_DESTINATION, "mkv_cooked/"), CHECK_FOLDER, successful_mkv_list, 10)
+
+        # Move the successful txt files to logs folder
+        move_files_parallel(os.path.join(MKV_DESTINATION, "mkv_cooked/"), os.path.join(MKV_DESTINATION, 'logs/'),
+                            successful_mkv_txt_list, 10)
+
+        # Move successful DPX sequence folders to dpx_completed/
+        successful_mkv_folder_list = [item.split('.')[0] for item in successful_mkv_list]
+
+        # Add list of moved items to post_rawcooked.log
+        if os.path.getsize(self.successfull_mkv_list_file) > 0:
+            # Log the message
             log(logfile,
-                f"Stalled/killed encoding: {stale_basename}. Adding to stalled list and deleting log file and Matroska")
-            with open(stale_encodings_file, "w") as file:
-                file.write(stale_fname)
-            file.close()
-            with open(ERRORS + fname_log + "_errors.log", "a") as file:
-                file.write(f"post_rawcooked {date}: Matroka {stale_fname} encoding stalled mid_process.")
-                file.write(f"    Matrosk and failed log deleted. DPX sequence will retry RAWCooked encoding.")
-                file.write(
-                    f"    Please contact the Knowledge and Collections Developer if this item repeatedly stalls.")
-            file.close()
+                "Successful Matroska files moved to check folder, DPX sequences for each moved to dpx_completed:\n")
+            with open(logfile, 'w') as file:
+                file.write("\n".join(os.listdir(self.successfull_mkv_list_file)))
+        else:
+            print("File is empty, skipping")
 
-# Add list of stalled logs to post_rawcooked.log
-if os.path.getsize(stale_encodings_file) > 0:
-    log(logfile, "Stalled files that will be deleted:")
-    with open(stale_encodings_file, 'r') as input_file, open(logfile, 'a') as output_file:
-        deletion_file_name = input_file.read()
-        output_file.write(deletion_file_name)
-        # Delete broken log files and delete broken Matroska files if they exist
-        os.remove(deletion_file_name)
-    input_file.close()
-    output_file.close()
-else:
-    print("No stale encodings to process at this time. Skipping.")
+    def check_big_reversibility_file(self):
+        # ==========================================================================
+        # Error: the reversibility file is becoming big. --output-version 2 pass ===
+        # =========================================================================
+        with os.scandir(os.path.join(MKV_DESTINATION, "mkv_cooked/")) as entries:
+            for entry in entries:
+                if entry.name.endswith(".mkv.txt"):
+                    error_check = False
+                    retry_check = False
+                    mkv_fname1 = entry.name
+                    dpx_folder1 = mkv_fname1.split(".")[0]
+                    with open(f"{MKV_DESTINATION}mkv_cooked/{entry.name}") as file:
+                        for line in file:
+                            if line.find(
+                                    "'Error: undecodable file is becoming too big.\|Error: the reversibility file is "
+                                    "becoming big.'") != -1:
+                                error_check = True
+                    if error_check:
+                        log(logfile, "MKV " + mkv_fname1 + " log has no large reversibility file warning. Skipping")
+                    else:
+                        with open(self.reversibility_list_file) as file:
+                            for line in file:
+                                if line.find(mkv_fname1):
+                                    retry_check = True
+                        file.close()
+                        if retry_check:
+                            log(logfile, f"NEW ENCODING ERROR: ${mkv_fname1} adding to reversibility_list")
+                            with open(self.reversibility_list_file, "w") as file:
+                                file.write(f"{DPX_PATH}dpx_to_cook/{dpx_folder1}")
+                            file.close()
+                            shutil.move(entry.name, MKV_DESTINATION + "logs/retry_" + mkv_fname1 + ".txt")
 
-# Write an END note to the logfile
-log(logfile, "===================== Post-rawcook workflows ENDED =====================")
+                        else:
+                            log(logfile,
+                                f"REPEAT ENCODING ERROR: {mkv_fname1} encountered repeated reversilibity data error")
+                            with open(ERRORS + dpx_folder1 + "_errors.log", "w+") as file:
+                                file.write(
+                                    f"post_rawcooked {date}: {mkv_fname1} Repeated reversibility data error for "
+                                    f"sequence:")
+                                file.write(f"    {DPX_PATH}dpx_to_cook/{dpx_folder1}")
+                                file.write("    The FFV1 Matroska will be deleted.")
+                                file.write(
+                                    "Please contact the Knowledge and Collections Developer about this repeated "
+                                    "reversibility failure.")
+                            file.close()
+                            with open(self.matroska_deletion_file, "w") as file:
+                                file.write(mkv_fname1)
+                            file.close()
+                            shutil.move(MKV_DESTINATION + "mkv_cooked/" + entry.name,
+                                        MKV_DESTINATION + "logs/fail_" + mkv_fname1 + ".txt")
 
-# Update the count of successful cooks at top of the success log
-# First create new temp_success_log with timestamp
-with open(MKV_DESTINATION + "temp_rawcooked_success.log", "w") as output_file:
-    output_file.write(f"===================== Updated ===================== {date}")
-    # Count lines in success_log and create count variable, output that count to new success log, then output all lines with /home* to the new log
-    with open(MKV_DESTINATION + "rawcooked_success.log", "r") as input_file:
-        lines = input_file.readlines()
-        success_count = len(lines)
-        for line in lines:
-            output_file.write(line)
-    input_file.close()
-    output_file.write(f"===================== Successful cooks: {success_count} ===================== {date}")
-output_file.close()
+        # Add list of reversibility data error to dpx_post_rawcooked.log
+        if os.path.getsize(self.matroska_deletion_file) > 0:
+            log(logfile, "MKV files that will be deleted due to reversibility data error in logs (if present):")
+            with open(self.matroska_deletion_file, 'r') as input_file, open(logfile, 'a') as output_file:
+                deletion_file_name = input_file.read()
+                output_file.write(deletion_file_name)
+                # Delete broken Matroska files if they exist (unlikely as error exits before encoding)
+                if os.path.exists(MKV_DESTINATION + "mkv_cooked/" + deletion_file_name):
+                    os.remove(MKV_DESTINATION + "mkv_cooked/" + deletion_file_name)
+            input_file.close()
+            output_file.close()
+        else:
+            print("No MKV files for deletion. Skipping.")
 
-# Sort the log and remove any non-unique lines
-with open(MKV_DESTINATION + "temp_rawcooked_success.log", "r") as file:
-    lines = file.readlines()
-    unique = list(set(lines))
-    unique.sort()
-file.close()
+        # Add reversibility list to logs for reference
+        if os.path.getsize(self.reversibility_list_file):
+            log(logfile, "DPX sequences that will be re-encoded using --output-version 2:")
+            with open(self.reversibility_list_file, 'r') as input_file, open(logfile, 'a') as output_file:
+                output_file.write(input_file.read())
+            input_file.close()
+            output_file.close()
+        else:
+            print("No DPX sequences for re-encoding using --output-version 2. Skipping.")
 
-with open(MKV_DESTINATION + "temp_rawcooked_success_unique.log", "w") as file:
-    file.writelines(unique)
+        # TODO make these checks functions rather than checking everything separately
 
-for filename in file_names:
-    os.remove(filename)
+    def check_general_errors(self):
 
-shutil.move(MKV_DESTINATION + "temp_rawcooked_success_unique.log", MKV_DESTINATION + "rawcooked_success.log")
+        # ===================================================================================
+        # General Error/Warning message failure checks - retry or raise in current errors ===
+        # ===================================================================================
+        error_messages = ["Reversibility was checked, issues detected, see below.", "Error:", "Conversion failed!",
+                          "Please contact info@mediaarea.net if you want support of such content."]
+        with os.scandir(os.path.join(MKV_DESTINATION, "mkv_cooked/")) as entries:
+            for entry in entries:
+                error_check = False
+                mkv_fname = entry.name
+                dpx_folder = entry.path
+                if entry.name.endswith("mkv.txt"):
+                    with open(entry.name, "r") as file:
+                        for line in file:
+                            for message in error_messages:
+                                if message in line:
+                                    error_check = True
+                if error_check:
+                    log(logfile, f"UNKNOWN ENCODING ERROR: {mkv_fname} encountered error")
+                    with open(dpx_folder + "_errors.log", "w") as file:
+                        file.write(DPX_PATH + "dpx_to_cook/" + dpx_folder)
+                        file.write(f"post_rawcooked {date}: {mkv_fname} Repeat encoding error raised for sequence:")
+                        file.write(f"    {DPX_PATH}dpx_to_cook/{dpx_folder}")
+                        file.write(f"    Matroska file will be deleted.")
+                        file.write(
+                            f"    Please contact the Knowledge and Collections Developer about this repeated encoding "
+                            f"failure")
 
+                    with open(self.matroska_deletion_file, "a") as file:
+                        file.write(f"{mkv_fname}")
+                    file.close()
+                    shutil.move(entry.name, MKV_DESTINATION + "logs/fail_" + mkv_fname + ".txt")
+                else:
+                    log(logfile,
+                        f"MKV {mkv_fname} log has no error messages. Likely an interrupted or incomplete encoding")
+
+    def killed_process_workflow(self):
+        # ===============================================================
+        # FOR ==== INCOMPLETE ==== - i.e. killed processes ==============
+        # ===============================================================
+
+        # This block manages the remaining INCOMPLETE cooks that have been killed or stalled mid-encoding
+        with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
+            for entry in entries:
+                if entry.name.endswith(".mkv.txt"):
+                    stale_fname = entry.name
+                    stale_basename = entry.path
+                    fname_log = entry.path.split('/')[0]
+                    log(logfile,
+                        f"Stalled/killed encoding: {stale_basename}. Adding to stalled list and deleting log file and "
+                        f"Matroska")
+                    with open(self.stale_encodings_file, "w") as file:
+                        file.write(stale_fname)
+                    with open(ERRORS + fname_log + "_errors.log", "a") as file:
+                        file.write(f"post_rawcooked {date}: Matroka {stale_fname} encoding stalled mid_process.")
+                        file.write(f"    Matrosk and failed log deleted. DPX sequence will retry RAWCooked encoding.")
+                        file.write(
+                            f" Please contact the Knowledge and Collections Developer if this item repeatedly stalls.")
+
+        # Add list of stalled logs to post_rawcooked.log
+        if os.path.getsize(self.stale_encodings_file) > 0:
+            log(logfile, "Stalled files that will be deleted:")
+            with open(self.stale_encodings_file, 'r') as input_file, open(logfile, 'a') as output_file:
+                deletion_file_name = input_file.read()
+                output_file.write(deletion_file_name)
+                # Delete broken log files and delete broken Matroska files if they exist
+                os.remove(deletion_file_name)
+            input_file.close()
+            output_file.close()
+        else:
+            print("No stale encodings to process at this time. Skipping.")
+
+        # Write an END note to the logfile
+        log(logfile, "===================== Post-rawcook workflows ENDED =====================")
+
+    def update_success_count(self):
+        # Update the count of successful cooks at top of the success log
+        # First create new temp_success_log with timestamp
+        with open(MKV_DESTINATION + "temp_rawcooked_success.log", "w") as output_file:
+            output_file.write(f"===================== Updated ===================== {date}")
+            # Count lines in success_log and create count variable, output that count to new success log, then output
+            # all lines with /home* to the new log
+            with open(MKV_DESTINATION + "rawcooked_success.log", "r") as input_file:
+                lines = input_file.readlines()
+                success_count = len(lines)
+                for line in lines:
+                    output_file.write(line)
+            output_file.write(f"===================== Successful cooks: {success_count} ===================== {date}")
+
+    def clean(self):
+        # Sort the log and remove any non-unique lines
+        with open(MKV_DESTINATION + "temp_rawcooked_success.log", "r") as file:
+            lines = file.readlines()
+            unique = list(set(lines))
+            unique.sort()
+        file.close()
+
+        with open(MKV_DESTINATION + "temp_rawcooked_success_unique.log", "w") as file:
+            file.writelines(unique)
+
+        for filename in self.file_names:
+            os.remove(filename)
+
+        shutil.move(MKV_DESTINATION + "temp_rawcooked_success_unique.log", MKV_DESTINATION + "rawcooked_success.log")
+
+
+    def execute(self):
+        self.process()
+        self.check_mediaconch_policies()
+        self.move_success_files()
+        self.check_big_reversibility_file()
+        self.check_general_errors()
+        self.killed_process_workflow()
+        self.update_success_count()
+        self.clean()
+
+
+if __name__ == '__main__':
+    post_rawcook = DpxPostRawcook()
+    post_rawcook.execute()

--- a/scripts/dpx_post_rawcook.py
+++ b/scripts/dpx_post_rawcook.py
@@ -63,8 +63,7 @@ class DpxPostRawcook:
             for entry in entries:
                 filename = entry.name
                 fname_log = filename.split('.')[0]
-                if filename.endswith(".mkv") or filename.endswith(
-                        ".rawcooked_reversibility_data"):  # TODO check this file name ending. Should be .mkv only
+                if filename.endswith(".mkv"):
                     check = check_mediaconch_policy(MKV_POLICY, filename)
                     check_str = check.stdout.decode()
                     if ".mkv.r" in check_str:  # check_str.startswith('pass!'):

--- a/scripts/dpx_post_rawcook.py
+++ b/scripts/dpx_post_rawcook.py
@@ -1,5 +1,6 @@
 import shutil
 import mmap
+import sys
 from datetime import datetime
 
 from utils.logging_utils import log
@@ -8,7 +9,7 @@ from dotenv import load_dotenv
 
 import os
 
-from utils.shell_utils import check_mediaconch_policy, move_files_parallel
+from utils.shell_utils import check_mediaconch_policy
 
 load_dotenv()
 
@@ -25,42 +26,41 @@ SCRIPT_LOG = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('DPX_SCRIPT
 REVIEW_FAILS_PATH = os.path.join(os.environ.get('FILM_OPS'), os.environ.get('DPX_REVIEW'), 'post_rawcook_fails/')
 MKV_COOKED_PATH = os.path.join(MKV_DESTINATION, 'mkv_cooked/')
 
-logfile = os.path.join(SCRIPT_LOG, "dpx_post_rawcook.log")
-date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-
 
 class DpxPostRawcook:
     def __init__(self):
+        self.logfile = os.path.join(SCRIPT_LOG, "dpx_post_rawcook.log")
+        self.date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         self.temp_medicaconch_policy_fails_file = os.path.join(MKV_DESTINATION, "temp_medicaconch_policy_fails.txt")
-        self.successfull_mkv_list_file = os.path.join(MKV_DESTINATION, "successfull_mkv_list.txt")
-        self.matroska_deletion_file = os.path.join(MKV_DESTINATION, "matroska_deletion.txt")
-        self.matroske_deletion_list_file = os.path.join(MKV_DESTINATION, "matroske_deletion_list.txt")
-        self.stale_encodings_file = os.path.join(MKV_DESTINATION, "stale_encodings.txt")
-        self.error_list_file = os.path.join(MKV_DESTINATION, "error_list.txt")
-        self.reversibility_list_file = os.path.join(MKV_DESTINATION, "reversibility_list.txt")
-
-        self.file_names = [
-            self.temp_medicaconch_policy_fails_file, self.successfull_mkv_list_file, self.matroska_deletion_file,
-            self.matroske_deletion_list_file, self.stale_encodings_file, self.error_list_file,
-            self.reversibility_list_file
-        ]
 
     def process(self):
-        # Check mkv_cooked/ folder populated before starting log writes
-        if any(os.scandir(MKV_DESTINATION + 'mkv_cooked/')):
-            log(logfile, "===================== Post-RAWcook workflows STARTED =====================")
-            log(logfile, "Files present in mkv_cooked folder, checking if ready for processing...")
-        else:
-            print("MKV folder empty, script exiting")
+        """Initiates the Post Rawcooked Workflow
 
-        for file_name in self.file_names:
-            with open(file_name, 'w'):
+        Creates the temporary and log files (if not present)
+        Also checks if the mkv_cooked folder have any files to process
+        """
+        if not os.path.exists(self.logfile):
+            with open(self.logfile, 'w+'):
                 pass
 
+        # Check mkv_cooked/ folder populated before starting log writes
+        if any(os.scandir(MKV_DESTINATION + 'mkv_cooked/')):
+            log(self.logfile, "===================== Post-RAWcook workflows STARTED =====================")
+            log(self.logfile, "Files present in mkv_cooked folder, checking if ready for processing...")
+        else:
+            print("MKV folder empty, script exiting")
+            sys.exit(1)
+
+        with open(self.temp_medicaconch_policy_fails_file, 'w+'):
+            pass
+
     def check_mediaconch_policies(self):
-        # ==========================================================================
-        # Matroska checks using MediaConch policy
-        # ==========================================================================
+        """For every .mkv files it checks against a policy using mediaconch
+
+        Scans through the mkv_cooked folder for .mkv files and run mediaconch
+        If a file fails the check, the path of that file and the respective .mkv.txt file gets appended into a
+        temporary .txt file named temp_medicaconch_policy_fails.txt
+        """
         with os.scandir(MKV_COOKED_PATH) as entries:
             for entry in entries:
                 file_name = entry.name
@@ -69,11 +69,11 @@ class DpxPostRawcook:
                     mediaconch_output = check_mediaconch_policy(MKV_POLICY, file_path)
                     standard_output = mediaconch_output.stdout.decode()
                     if "pass!" in standard_output:  # check_str.startswith('pass!'):
-                        log(logfile,
+                        log(self.logfile,
                             f"PASS: RAWcooked MKV file {file_name} has passed the Mediaconch policy")
                     else:
-                        log(logfile, f"FAIL: RAWcooked MKV {file_name} has failed the mediaconch policy")
-                        log(logfile, f"MEDIACONCH_FAILED_RESULT: {mediaconch_output}")
+                        log(self.logfile, f"FAIL: RAWcooked MKV {file_name} has failed the mediaconch policy")
+                        log(self.logfile, f"MEDIACONCH_FAILED_RESULT: {mediaconch_output}")
 
                         # Write both the failed mkv file along with the corresponding txt file
                         with open(self.temp_medicaconch_policy_fails_file, "a+") as file:
@@ -82,8 +82,14 @@ class DpxPostRawcook:
                             file.write(f"{file_path}\n")
                             file.write(f"{txt_file_path}\n")
 
-    # Moves the failed mkv file and its corresponding txt file into dpx_for_review/post_rawcook_fails
     def move_failed_files(self):
+        """Moves the failed mkv file and its corresponding txt file into dpx_for_review/post_rawcook_fails/
+
+        Reads temp_medicaconch_policy_fails.txt
+        Moves the .mkv files into dpx_for_review/post_rawcook_fails/mkv_files/
+        Moves the .mkv.txt files into  dpx_for_review/post_rawcook_fails/rawcook_output_logs/
+        Remaining .mkv files inside the mkv_cooked have passed the mediaconch checks
+        """
         with open(self.temp_medicaconch_policy_fails_file, 'r') as file:
             for file_path in file:
                 file_path = file_path.strip()
@@ -93,66 +99,13 @@ class DpxPostRawcook:
                 elif file_path.endswith(".txt"):
                     shutil.move(file_path, os.path.join(REVIEW_FAILS_PATH, 'rawcook_output_logs/'))
 
-    # def move_success_files(self):
-    #     # ===================================================================================
-    #     # Log check passes move to MKV Check folder and logs folders, and DPX folder move ===
-    #     # ===================================================================================
-    #     with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
-    #         for entry in entries:
-    #             filename = entry.name
-    #             if filename.endswith("mkv.txt"):
-    #                 with open(MKV_DESTINATION + "mkv_cooked/" + filename, 'r') as file:
-    #                     for line in file:
-    #                         mkv_filename = filename.split('.')[0] + '.mkv'
-    #                         if line.find('Reversibility was checked, no issue detected.') != -1:
-    #                             print(mkv_filename)
-    #                             dpx_success_path = entry.path
-    #                             log(logfile,
-    #                                 "COMPLETED: RAWcooked MKV " + mkv_filename + "has completed successfully and will "
-    #                                                                              "be moved to check folder")
-    #                             with open(MKV_DESTINATION + "rawcooked_success.log", "a") as f:
-    #                                 f.write(dpx_success_path)
-    #                             with open(self.successfull_mkv_list_file, "a") as f:
-    #                                 f.write(mkv_filename)
-    #                         else:
-    #                             log(logfile,
-    #                                 "SKIP: Matroska " + mkv_filename + " has not completed, or has errors detected")
-    #
-    #     # Move successfully encoded MKV files to check folder
-    #     successful_mkv_list = []
-    #     successful_mkv_txt_list = []
-    #     with open(self.successfull_mkv_list_file, 'r') as file:
-    #         for line in file:
-    #             if line.endswith(".mkv"):
-    #                 successful_mkv_list.append(line)
-    #             elif line.endswith(".txt"):
-    #                 successful_mkv_txt_list.append(line)
-    #
-    #     # Move successfully encoded MKV files to check folder
-    #     move_files_parallel(os.path.join(MKV_DESTINATION, "mkv_cooked/"), CHECK_FOLDER, successful_mkv_list, 10)
-    #
-    #     # Move the successful txt files to logs folder
-    #     move_files_parallel(os.path.join(MKV_DESTINATION, "mkv_cooked/"), os.path.join(MKV_DESTINATION, 'logs/'),
-    #                         successful_mkv_txt_list, 10)
-    #
-    #     # Move successful DPX sequence folders to dpx_completed/
-    #     successful_mkv_folder_list = [item.split('.')[0] for item in successful_mkv_list]
-    #
-    #     # Add list of moved items to post_rawcooked.log
-    #     if os.path.getsize(self.successfull_mkv_list_file) > 0:
-    #         # Log the message
-    #         log(logfile,
-    #             "Successful Matroska files moved to check folder, DPX sequences for each moved to dpx_completed:\n")
-    #         with open(logfile, 'w') as file:
-    #             file.write("\n".join(os.listdir(self.successfull_mkv_list_file)))
-    #     else:
-    #         print("File is empty, skipping")
-
     def check_general_errors(self):
+        """Checks the mediaconch passed .mkv files for any other RAWCooked errors
 
-        # ===================================================================================
-        # General Error/Warning message failure checks - retry or raise in current errors ===
-        # ===================================================================================
+        Reads each of the .mkv.txt files and checks for messages stored in error_messages
+        If error found, then the repective .mkv file are moved to dpx_for_review/post_rawcook_fails/mkv_files/
+        And the .mkv.txt files are moved to dpx_for_review/post_rawcook_fails/rawcook_output_logs/
+        """
         error_messages = [b"Reversibility was checked, issues detected, see below.", b"Error:", b"Conversion failed!",
                           b"Please contact info@mediaarea.net if you want support of such content."]
 
@@ -160,6 +113,7 @@ class DpxPostRawcook:
         with os.scandir(MKV_COOKED_PATH) as files:
             txt_file_list = [file.path for file in files if file.name.endswith("mkv.txt")]
 
+        # used mmap as byte operations are faster
         for txt_file_path in txt_file_list:
             with open(txt_file_path, 'rb', 0) as file:
                 s = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
@@ -168,80 +122,30 @@ class DpxPostRawcook:
                         error_file_path_list.append(txt_file_path)
                         break
 
-        if len(error_file_path_list) > 0:
-            for txt_file_path in error_file_path_list:
-                txt_file_name = txt_file_path.split('/')[-1]
-                mkv_file_name = txt_file_name.replace('.txt', '')
-                mkv_file_path = txt_file_path.replace('.txt', '')
-                log(logfile, f"UNKNOWN ENCODING ERROR: {mkv_file_name} encountered error")
-                log(logfile, f"Moving {mkv_file_name} and {mkv_file_name}.txt for manual review")
-                shutil.move(mkv_file_path, os.path.join(REVIEW_FAILS_PATH, 'mkv_files/'))
-                shutil.move(txt_file_path, os.path.join(REVIEW_FAILS_PATH, 'rawcook_output_logs/'))
-
-    def killed_process_workflow(self):
-        # ===============================================================
-        # FOR ==== INCOMPLETE ==== - i.e. killed processes ==============
-        # ===============================================================
-
-        # This block manages the remaining INCOMPLETE cooks that have been killed or stalled mid-encoding
-        with os.scandir(MKV_DESTINATION + "mkv_cooked/") as entries:
-            for entry in entries:
-                if entry.name.endswith(".mkv.txt"):
-                    stale_fname = entry.name
-                    stale_basename = entry.path
-                    fname_log = entry.path.split('/')[0]
-                    log(logfile,
-                        f"Stalled/killed encoding: {stale_basename}. Adding to stalled list and deleting log file and "
-                        f"Matroska")
-                    with open(self.stale_encodings_file, "w") as file:
-                        file.write(stale_fname)
-                    with open(ERRORS + fname_log + "_errors.log", "a") as file:
-                        file.write(f"post_rawcooked {date}: Matroka {stale_fname} encoding stalled mid_process.")
-                        file.write(f"    Matrosk and failed log deleted. DPX sequence will retry RAWCooked encoding.")
-                        file.write(
-                            f" Please contact the Knowledge and Collections Developer if this item repeatedly stalls.")
-
-        # Add list of stalled logs to post_rawcooked.log
-        if os.path.getsize(self.stale_encodings_file) > 0:
-            log(logfile, "Stalled files that will be deleted:")
-            with open(self.stale_encodings_file, 'r') as input_file, open(logfile, 'a') as output_file:
-                deletion_file_name = input_file.read()
-                output_file.write(deletion_file_name)
-                # Delete broken log files and delete broken Matroska files if they exist
-                os.remove(deletion_file_name)
-            input_file.close()
-            output_file.close()
-        else:
-            print("No stale encodings to process at this time. Skipping.")
-
-        # Write an END note to the logfile
-        log(logfile, "===================== Post-rawcook workflows ENDED =====================")
+        # Moves files with general error into dpx_for_review/post_rawcook_fails
+        for txt_file_path in error_file_path_list:
+            txt_file_name = txt_file_path.split('/')[-1]
+            mkv_file_name = txt_file_name.replace('.txt', '')
+            mkv_file_path = txt_file_path.replace('.txt', '')
+            log(self.logfile, f"UNKNOWN ENCODING ERROR: {mkv_file_name} encountered error")
+            log(self.logfile, f"Moving {mkv_file_name} and {mkv_file_name}.txt for manual review")
+            shutil.move(mkv_file_path, os.path.join(REVIEW_FAILS_PATH, 'mkv_files/'))
+            shutil.move(txt_file_path, os.path.join(REVIEW_FAILS_PATH, 'rawcook_output_logs/'))
 
     def clean(self):
-        # Sort the log and remove any non-unique lines
-        with open(MKV_DESTINATION + "temp_rawcooked_success.log", "r") as file:
-            lines = file.readlines()
-            unique = list(set(lines))
-            unique.sort()
-        file.close()
+        """Concludes the workflow
 
-        with open(MKV_DESTINATION + "temp_rawcooked_success_unique.log", "w") as file:
-            file.writelines(unique)
-
-        for filename in self.file_names:
-            os.remove(filename)
-
-        shutil.move(MKV_DESTINATION + "temp_rawcooked_success_unique.log", MKV_DESTINATION + "rawcooked_success.log")
+        Deletes all the temporary .txt files created during the workflow
+        """
+        log(self.logfile, f"Concluding workflow by deleting temporary files")
+        os.remove(self.temp_medicaconch_policy_fails_file)
+        log(self.logfile, f"============= DPX Post-RAWcook workflow ENDED =============")
 
     def execute(self):
         self.process()
         self.check_mediaconch_policies()
         self.move_failed_files()
-        # self.move_success_files()
-        # self.check_big_reversibility_file()
         self.check_general_errors()
-        # self.killed_process_workflow()
-        # self.update_success_count()
         self.clean()
 
 

--- a/scripts/dpx_rawcook.py
+++ b/scripts/dpx_rawcook.py
@@ -29,13 +29,23 @@ def process_mkv(file_name: str, md5_checksum: bool = False):
     # else ''} {DPX_PATH}{line} -o {MKV_DEST}mkv_cooked/{line}.mkv &>> {MKV_DEST}mkv_cooked/{line}.mkv.txt"
     file_name = file_name.rstrip()
     string_command = f"rawcooked --license 004B159A2BDB07331B8F2FDF4B2F -y --all --no-accept-gaps -s 5281680 {'--framemd5' if md5_checksum else ''} {DPX_PATH}{file_name} -o {MKV_DEST}mkv_cooked/{file_name}.mkv"
-    output_file_name = f"{MKV_DEST}mkv_cooked/{file_name}.mkv.txt"
+    output_txt_file = f"{MKV_DEST}mkv_cooked/{file_name}.mkv.txt"
     command = string_command.split(" ")
     command = [c for c in command if len(c) > 0]
     command = list(command)
     print(command)
-    with subprocess.Popen(command, text=True) as proc:
-        proc.wait()
+    subprocess_logs = []
+    with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) as p:
+        for line in p.stderr:
+            subprocess_logs.append(line)
+            print(f"{file_name} : {line}")
+        for line in p.stdout:
+            subprocess_logs.append(line)
+            print(f"{file_name} : {line}")
+
+    std_logs = ''.join(subprocess_logs)
+    with open(output_txt_file, 'a+') as file:
+        file.write(std_logs)
 
 
 def process_mkv_output_v2(line):

--- a/utils/shell_utils.py
+++ b/utils/shell_utils.py
@@ -59,7 +59,6 @@ def check_mediaconch_policy(policy_path, filename):
 
     command = ['mediaconch', '--force', '-p', policy_path, filename]
     check = subprocess.run(command, capture_output=True)
-
     return check
 
 


### PR DESCRIPTION
The current workflow is 
- The `.mvk` files are checked one by one against policy using mediaconch.
- The Failed `.mkv` and the respective `.mkv.txt` file paths are added to a temporary `.txt` file
- The paths are read from the temporary `.txt` file and `.mkv` files are moved to  `dpx_for_review/post_rawcook_fails/mkv_files/` and the `.mkv.txt` files are moved to `dpx_for_review/post_rawcook_fails/rawcook_output_logs/`
- The mediaconch passed files are checked for RAWCooked errors and if error found,  `.mkv` files are moved to `dpx_for_review/post_rawcook_fails/mkv_files/` and the `.mkv.txt` files are moved to `dpx_for_review/post_rawcook_fails/rawcook_output_logs/`
- The temporary file is deleted